### PR TITLE
put security camera volume back to default

### DIFF
--- a/def/security_camera_lt3.def
+++ b/def/security_camera_lt3.def
@@ -2,7 +2,6 @@ entityDef lt3:security_camera
 {
 	"inherit"       "atdm:security_camera01_compact" 
 
-    "s_volume"      "-25"
     "snd_moving"    "silence"
 
     "spotLight"     "0"


### PR DESCRIPTION
fixes #28 

The volume reduction wasn't really needed as I had already set snd_moving to 'silence', which was the part that was too loud.