### PR TITLE
make mosque office door unpickable

### DIFF
--- a/maps/lt3.darkradiant
+++ b/maps/lt3.darkradiant
@@ -2,9 +2,9 @@ DarkRadiant Map Information File Version 2
 {
 	MapProperties
 	{
-		KeyValue { "EditTimeInSeconds" "2509810" } 
-		KeyValue { "LastCameraAngle" "1.2 107.8 0" } 
-		KeyValue { "LastCameraPosition" "-777.865 -518.65 -265.972" } 
+		KeyValue { "EditTimeInSeconds" "2510437" } 
+		KeyValue { "LastCameraAngle" "-0.600002 348.2 0" } 
+		KeyValue { "LastCameraPosition" "-3730.09 1071.14 386.402" } 
 		KeyValue { "LastShaderClipboardMaterial" "textures/water_source/water_reflective_lt3" } 
 	}
 	SelectionSets
@@ -12,7 +12,7 @@ DarkRadiant Map Information File Version 2
 	}
 	MapEditTimings
 	{
-		TotalSecondsEdited { 2509810 }
+		TotalSecondsEdited { 2510437 }
 	}
 	Layers
 	{


### PR DESCRIPTION
Also a bunch of other doors were set with pickable = 1, but couldn't be picked because lock type and pins weren't set.  Changed to pickable = 0 anyways.

fixes #343 